### PR TITLE
Fix Liquid syntax error

### DIFF
--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -13,7 +13,7 @@ layout: default
 
 <h1>Writing</h1>
 <ul>
-{% for p in site.posts do %}
+{% for p in site.posts %}
   {% if p.author == page.author %}
     <li><a href="{{ p.url }}">{{ p.title }}</a></li>
   {% endif %}


### PR DESCRIPTION
When running `jekyll serve`, an error will be thrown due a syntax error. This will fix clear up the error.

```
      Generating...
    Liquid Warning: Liquid syntax error (line 12): Expected end_of_string but found id in "p in site.posts do" in /_layouts/author.html
    Liquid Warning: Liquid syntax error (line 12): Expected end_of_string but found id in "p in site.posts do" in /_layouts/author.html
                    done in 0.955 seconds.
```
